### PR TITLE
Prevent unicode escaping

### DIFF
--- a/src/Services/Json/Handler.php
+++ b/src/Services/Json/Handler.php
@@ -33,7 +33,7 @@ abstract class Handler
     {
         File::put(
             $this->jsonFileName($locale, $subDir),
-            json_encode($langFile, JSON_FORCE_OBJECT | ($subDir ? JSON_PRETTY_PRINT : 0))
+            json_encode($langFile, JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE | ($subDir ? JSON_PRETTY_PRINT : 0))
         );
     }
 


### PR DESCRIPTION
When I add new translations for new language and save it here /system/localisation/editTexts
 I see that 
    "7 days": "7 дней",
    "30 days": "30 дней",

became:
    "7 days": "7 \u0434\u043d\u0435\u0439",
    "30 days": "30 \u0434\u043d\u0435\u0439",

It's not convenient. For example if i search phrase from source code.
So JSON_UNESCAPED_UNICODE key prevent this transformation.